### PR TITLE
Remove unnecessary pass by reference.

### DIFF
--- a/com.unity.transport/Runtime/DataStream.cs
+++ b/com.unity.transport/Runtime/DataStream.cs
@@ -599,7 +599,7 @@ namespace Unity.Networking.Transport
         /// <param name="ctx"></param>
         /// <param name="dest"></param>
         /// <param name="length"></param>
-        public void ReadBytesIntoArray(ref Context ctx, ref byte[] dest, int length)
+        public void ReadBytesIntoArray(ref Context ctx, byte[] dest, int length)
         {
             for (var i = 0; i < length; ++i)
                 dest[i] = ReadByte(ref ctx);

--- a/com.unity.transport/Tests/Editor/DataStreamTests.cs
+++ b/com.unity.transport/Tests/Editor/DataStreamTests.cs
@@ -69,7 +69,7 @@ namespace Unity.Networking.Transport.Tests
                 dataStream.Write((byte) 'c');
                 var reader = new DataStreamReader(dataStream, 0, dataStream.Length);
                 var readerCtx = default(DataStreamReader.Context);
-                reader.ReadBytesIntoArray(ref readerCtx, ref byteArray, dataStream.Length);
+                reader.ReadBytesIntoArray(ref readerCtx, byteArray, dataStream.Length);
                 readerCtx = default(DataStreamReader.Context);
                 for (int i = 0; i < reader.Length; ++i)
                 {


### PR DESCRIPTION
This version of ReadBytesIntoArray unnecessarily uses a reference to a byte[] for the dest paramter. In addition to being unnecessary, it gives the caller the impression that dest may be modified to point to a newly allocated byte[], which is not the case.